### PR TITLE
Rewrite Object.fromFlatEntries in F#

### DIFF
--- a/src/Feliz.MaterialUI/Flatten.fs
+++ b/src/Feliz.MaterialUI/Flatten.fs
@@ -8,25 +8,27 @@ open Fable.Core
 module Object =
 
   [<Emit("""
-function setProperty(target, key, value) {
-  const sepIdx = key.indexOf('.')
-  if (sepIdx === -1) {
-    target[key] = value
-  } else {
-    const topKey = key.substring(0, sepIdx)
-    const nestedKey = key.substring(sepIdx + 1)
-    if (target[topKey] === undefined) {
-      target[topKey] = {}
+(function () {
+  function setProperty(target, key, value) {
+    const sepIdx = key.indexOf('.')
+    if (sepIdx === -1) {
+      target[key] = value
+    } else {
+      const topKey = key.substring(0, sepIdx)
+      const nestedKey = key.substring(sepIdx + 1)
+      if (target[topKey] === undefined) {
+        target[topKey] = {}
+      }
+      setProperty(target[topKey], nestedKey, value)
     }
-    setProperty(target[topKey], nestedKey, value)
   }
-}
 
-const target = {}
-for (let kv of $0) {
-  setProperty(target, kv[0], kv[1])
-}
+  const target = {}
+  for (let kv of $0) {
+    setProperty(target, kv[0], kv[1])
+  }
 
-return target
+  return target
+})()
 """)>]
   let fromFlatEntries (kvs: seq<string * obj>) : obj = jsNative

--- a/src/Feliz.MaterialUI/Flatten.fs
+++ b/src/Feliz.MaterialUI/Flatten.fs
@@ -2,33 +2,26 @@
 
 open System.ComponentModel
 open Fable.Core
-
+open Fable.Core.JsInterop
 
 [<EditorBrowsable(EditorBrowsableState.Never)>]
 module Object =
+  [<Emit("$0 === undefined")>]
+  let private isUndefined x = jsNative
 
-  [<Emit("""
-(function () {
-  function setProperty(target, key, value) {
-    const sepIdx = key.indexOf('.')
-    if (sepIdx === -1) {
-      target[key] = value
-    } else {
-      const topKey = key.substring(0, sepIdx)
-      const nestedKey = key.substring(sepIdx + 1)
-      if (target[topKey] === undefined) {
-        target[topKey] = {}
-      }
-      setProperty(target[topKey], nestedKey, value)
-    }
-  }
+  let fromFlatEntries (kvs: seq<string * obj>) : obj =
+    let rec setProperty (target : obj) (key : string) (value : obj) =
+      match key.IndexOf '.' with
+      | -1 -> target?(key) <- value
+      | sepIdx ->
+        let topKey = key.Substring (0, sepIdx)
+        let nestedKey = key.Substring (sepIdx + 1)
+        if isUndefined target?(topKey) then
+          target?(topKey) <- obj ()
+        setProperty target?(topKey) nestedKey value
 
-  const target = {}
-  for (let kv of $0) {
-    setProperty(target, kv[0], kv[1])
-  }
+    let target = obj ()
+    for (key, value) in kvs do
+      setProperty target key value
+    target
 
-  return target
-})()
-""")>]
-  let fromFlatEntries (kvs: seq<string * obj>) : obj = jsNative


### PR DESCRIPTION
This works around a regression in Fable 3, see fable-compiler/Fable#2249.

Note that the way this helper is written now, it will be added to every call site where it's used, so it will increase the size of the compiled JS code a bit. Maybe it's better to put it into a JS file and use one of Fables `import*` functions to import it? Or rewrite it in F# altogether, as suggested [here](https://github.com/fable-compiler/Fable/issues/2043#issuecomment-721761089)?