### PR TITLE
Add extra icon colors to props

### DIFF
--- a/src/Feliz.MaterialUI/Props.fs
+++ b/src/Feliz.MaterialUI/Props.fs
@@ -3307,6 +3307,8 @@ module icon =
     static member inline primary = Interop.mkAttr "color" "primary"
     static member inline secondary = Interop.mkAttr "color" "secondary"
     static member inline action = Interop.mkAttr "color" "action"
+    static member inline error = Interop.mkAttr "color" "success"
+    static member inline error = Interop.mkAttr "color" "warning"
     static member inline error = Interop.mkAttr "color" "error"
     static member inline disabled = Interop.mkAttr "color" "disabled"
 

--- a/src/Feliz.MaterialUI/Props.fs
+++ b/src/Feliz.MaterialUI/Props.fs
@@ -3309,6 +3309,7 @@ module icon =
     static member inline action = Interop.mkAttr "color" "action"
     static member inline error = Interop.mkAttr "color" "success"
     static member inline error = Interop.mkAttr "color" "warning"
+    static member inline error = Interop.mkAttr "color" "info"
     static member inline error = Interop.mkAttr "color" "error"
     static member inline disabled = Interop.mkAttr "color" "disabled"
 


### PR DESCRIPTION
The Material UI Icon API states that the color attribute can be:

| 'inherit'
| 'action'
| 'disabled'
| 'primary'
| 'secondary'
| 'error'
| 'info'
| 'success'
| 'warning'

The goal of this PR is to add the lacking options to the icon props.