### PR TITLE
Build fix: CreateFilterOptionsOptions needs explicit type level parameter

### DIFF
--- a/src/Feliz.MaterialUI/Autocomplete.fs
+++ b/src/Feliz.MaterialUI/Autocomplete.fs
@@ -8,7 +8,7 @@ open Fable.Core.JsInterop
 module AutocompleteHelpers =
 
   [<EditorBrowsable(EditorBrowsableState.Never)>]
-  let createFilterOptions (config: CreateFilterOptionsOptions) : Func<'option [], AutocompleteFilterOptionsState, 'option []> =
+  let createFilterOptions (config: CreateFilterOptionsOptions<_>) : Func<'option [], AutocompleteFilterOptionsState, 'option []> =
     import "createFilterOptions" "@material-ui/lab/Autocomplete"
 
 type Autocomplete =
@@ -21,7 +21,7 @@ type Autocomplete =
         ?trim: bool
       ) : 'option [] -> AutocompleteFilterOptionsState -> 'option []
       =
-    let opts = jsOptions<CreateFilterOptionsOptions>(fun o ->
+    let opts = jsOptions<CreateFilterOptionsOptions<_>>(fun o ->
       if ignoreAccents.IsSome then o.ignoreAccents <- ignoreAccents.Value
       if ignoreCase.IsSome then o.ignoreCase <- ignoreCase.Value
       if matchFrom.IsSome then o.matchFrom <- matchFrom.Value

--- a/src/Feliz.MaterialUI/Bindings.fs
+++ b/src/Feliz.MaterialUI/Bindings.fs
@@ -455,7 +455,7 @@ type AutocompleteOnChangeReason =
   | Clear
 
 
-type CreateFilterOptionsOptions =
+type CreateFilterOptionsOptions<'option> =
   abstract ignoreAccents: bool with get, set
   abstract ignoreCase: bool with get, set
   abstract matchFrom: AutocompleteMatchFrom with get, set


### PR DESCRIPTION
This is minimum adjustment required for the repository to build with new version of compiler.